### PR TITLE
Warn and exit if boto version is too old

### DIFF
--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -184,12 +184,16 @@ def main():
 
     # Boto < 2.0 missing __version__, hence try/except
     # S3 encryption support present in 2.1.0 and later
-    boto_err = 'Boto version 2.1.0 or later is required\n'
+    desired_boto = '2.1.0'
+    boto_err = 'Boto version %s or later is required\n' % desired_boto
     boto_err += 'Try: sudo easy_install boto\n'
+
     try:
-        if boto.__version__ < '2.1.0':
-                raise AttributeError
-    except AttributeError:
+        from pkg_resources import parse_version
+        if parse_version(boto.__version__) < parse_version(desired_boto):
+            sys.stdout.write(boto_err)
+            sys.exit(1)
+    except (AttributeError, NameError):
         sys.stdout.write(boto_err)
         sys.exit(1)
 

--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -181,7 +181,18 @@ def main():
     num_cb = 10
     rename = False
     copy_file = True
-    
+
+    # Boto < 2.0 missing __version__, hence try/except
+    # S3 encryption support present in 2.1.0 and later
+    boto_err = 'Boto version 2.1.0 or later is required\n'
+    boto_err += 'Try: sudo easy_install boto\n'
+    try:
+        if boto.__version__ < '2.1.0':
+                raise AttributeError
+    except AttributeError:
+        sys.stdout.write(boto_err)
+        sys.exit(1)
+
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         usage='%(prog)s [OPTIONS] SOURCE DESTINATION',


### PR DESCRIPTION
Support for S3 encryption appeared in Boto 2.1.0; support for S3 reduced redundancy appeared in Boto 2.0.  Sadly many Linux distributions still contain a pre-2.0 boto.  It's better to proactively check that the available boto library is recent enough for boto-rsync to function.
