### PR TITLE
Try distribute/setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import os, sys
 try:
-    from distutils.core import setup
-except ImportError:
     from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 install_requires = ['boto>=2.2.1']
 


### PR DESCRIPTION
distutils does not support `install_requires`.  Per the advice [1] from the BFDL-Packaging and for compatibility with FPM [2] building from a git clone try distribute/setuptools before distutils.  Perhaps this is wrong; I wouldn't be the first person driven to despair by Python packaging.

[1] http://python-notes.boredomandlaziness.org/en/latest/pep_ideas/core_packaging_api.html
[2] https://github.com/jordansissel/fpm/
