### PR TITLE
make os.walk return unicode strings

### DIFF
--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -469,7 +469,7 @@ def main():
                 sys.stdout.write('\n')
             
             # "Walk" the directory and upload files
-            for root, dirs, files in os.walk(path):
+            for root, dirs, files in os.walk(unicode(path)):
                 if no_recurse:
                     if root != path:
                         continue
@@ -599,7 +599,7 @@ def main():
                 if cloud_path and cloud_path in keys:
                     del(keys[cloud_path])
                 
-                for root, dirs, files in os.walk(path):
+                for root, dirs, files in os.walk(unicode(path)):
                     if no_recurse:
                         if root != path:
                             continue
@@ -889,7 +889,7 @@ def main():
             
             # If specified, perform deletes
             if delete:
-                for root, dirs, files in os.walk(path):
+                for root, dirs, files in os.walk(unicode(path)):
                     if no_recurse:
                         if root != path:
                             continue


### PR DESCRIPTION
s3 keys are in unicode, and our local paths need to be for same-file
comparisons.
