### PR TITLE
Enable feature for choosing others CallingFormat 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,9 @@ Options
                         read/write ACL.
   --endpoint HOST       Specify a specific S3 endpoint to connect to via
                         boto's "host" connection argument (S3 only).
+  --call-format	DefaultCallingFormat
+                        Choose CallingFormat, using vhost (default) or others
+                        CallingFormat.
   -g GRANT, --grant GRANT
                         A canned ACL policy that will be granted on each file
                         transferred to S3/GS. The value provided must be one

--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -24,6 +24,7 @@
 import sys, os, time, datetime, argparse, threading, signal
 from fnmatch import fnmatch
 import boto
+import boto.s3.connection
 
 __version__ = '0.8.1'
 
@@ -200,6 +201,10 @@ def main():
              'environment variable or a credentials file.'
         )
     parser.add_argument(
+        '--call-format', metavar='DefaultCallingFormat', default='boto.s3.connection.OrdinaryCallingFormat',
+        help='Choose CallingFormat, using vhost (default) or others CallingFormat.'
+        )
+    parser.add_argument(
         '--anon', action='store_true',
         help='Connect without credentials (S3 only). Useful if working ' + \
              'with others\' buckets that have a global read/write ACL.'
@@ -313,6 +318,7 @@ def main():
         cloud_secret_access_key = args.cloud_secret_access_key
         anon = args.anon
         endpoint = args.endpoint
+        call_format = args.call_format
         grant = args.grant
         metadata = args.metadata
         if not isinstance(metadata, dict):
@@ -419,7 +425,7 @@ def main():
         else:
             c = boto.connect_s3(aws_access_key_id=cloud_access_key_id,
                                 aws_secret_access_key=cloud_secret_access_key,
-                                host=endpoint)
+                                host=endpoint,calling_format=call_format)
     c.debug = debug
     b = c.get_bucket(cloud_bucket)
     if xfer_type in ['sync']:

--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -201,6 +201,10 @@ def main():
              'environment variable or a credentials file.'
         )
     parser.add_argument(
+         '--exclude', action='append', default=[],
+         help='Exclude files matching the specified pattern.'
+         )
+    parser.add_argument(
         '--call-format', metavar='DefaultCallingFormat', default='boto.s3.connection.OrdinaryCallingFormat',
         help='Choose CallingFormat, using vhost (default) or others CallingFormat.'
         )
@@ -320,6 +324,7 @@ def main():
         endpoint = args.endpoint
         call_format = args.call_format
         grant = args.grant
+        exclude = args.exclude
         metadata = args.metadata
         if not isinstance(metadata, dict):
             metadata = dict([meta.split(': ', 1) for meta in metadata])
@@ -547,6 +552,22 @@ def main():
                     fullpath = os.path.join(root, file)
                     key_name = cloud_path + get_key_name(fullpath, path)
                     file_size = os.path.getsize(fullpath)
+                    # determine if the file should be excluded according to command line arguments.
+                    excludeFile = False
+                    for excludePath in exclude:
+                        if fullpath.startswith(excludePath):
+                            excludeFile = True
+                            continue
+                        elif fullpath[len(path):].lstrip(os.sep).startswith(excludePath):
+                             excludeFile = True
+                             continue
+                    if excludeFile:
+                         sys.stdout.write(
+                             'Skipping %s (excluded path)\n' %
+                             fullpath[len(path):].lstrip(os.sep)
+                         )
+                         continue
+                     
                     
                     if file_size == 0:
                         if ignore_empty:

--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -553,6 +553,7 @@ def main():
                     key_name = cloud_path + get_key_name(fullpath, path)
                     file_size = os.path.getsize(fullpath)
                     # determine if the file should be excluded according to command line arguments.
+                    defaultExclude = False
                     excludeFile = False
                     for excludePath in exclude:
                         if fullpath.startswith(excludePath):
@@ -566,16 +567,19 @@ def main():
                              continue
                     #default exclude .svn and .git pattern
                     if '.svn' in fullpath:
-                            excludeFile = True
+                            defaultExclude = True
                             
                     if '.git' in fullpath:
-                            excludeFile = True
+                            defaultExclude = True
                             
                     if excludeFile:
                          sys.stdout.write(
                              'Skipping %s (excluded path)\n' %
                              fullpath[len(path):].lstrip(os.sep)
                          )
+                         continue
+                     
+                    if defaultExclude:
                          continue
                      
                     

--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -558,19 +558,19 @@ def main():
                         if fullpath.startswith(excludePath):
                             excludeFile = True
                             continue
-                        #default exclude .svn and .git pattern
-                        elif '.svn' in fullpath:
-                            excludeFile = True
-                            continue
-                        elif '.git' in fullpath:
-                            excludeFile = True
-                            continue
                         elif fullpath.endswith(excludePath):
                             excludeFile = True
                             continue
                         elif fullpath[len(path):].lstrip(os.sep).startswith(excludePath):
                              excludeFile = True
                              continue
+                    #default exclude .svn and .git pattern
+                    if '.svn' in fullpath:
+                            excludeFile = True
+                            continue
+                    if '.git' in fullpath:
+                            excludeFile = True
+                            continue
                     if excludeFile:
                          sys.stdout.write(
                              'Skipping %s (excluded path)\n' %

--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -567,10 +567,10 @@ def main():
                     #default exclude .svn and .git pattern
                     if '.svn' in fullpath:
                             excludeFile = True
-                            continue
+                            
                     if '.git' in fullpath:
                             excludeFile = True
-                            continue
+                            
                     if excludeFile:
                          sys.stdout.write(
                              'Skipping %s (excluded path)\n' %

--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -553,6 +553,7 @@ def main():
                     key_name = cloud_path + get_key_name(fullpath, path)
                     file_size = os.path.getsize(fullpath)
                     # determine if the file should be excluded according to command line arguments.
+                    defaultExclude = False
                     excludeFile = False
                     for excludePath in exclude:
                         if fullpath.startswith(excludePath):
@@ -566,10 +567,10 @@ def main():
                              continue
                     #default exclude .svn and .git pattern
                     if '.svn' in fullpath:
-                            excludeFile = True
+                            defaultExclude = True
                             
                     if '.git' in fullpath:
-                            excludeFile = True
+                            defaultExclude = True
                             
                     if excludeFile:
                          sys.stdout.write(

--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -558,6 +558,16 @@ def main():
                         if fullpath.startswith(excludePath):
                             excludeFile = True
                             continue
+                        #default exclude .svn and .git pattern
+                        elif '.svn' in fullpath:
+                            excludeFile = True
+                            continue
+                        elif '.git' in fullpath:
+                            excludeFile = True
+                            continue
+                        elif fullpath.endswith(excludePath):
+                            excludeFile = True
+                            continue
                         elif fullpath[len(path):].lstrip(os.sep).startswith(excludePath):
                              excludeFile = True
                              continue


### PR DESCRIPTION
Add "--call-format" to arguments, so users can choose different CallingFormat . Default boto will use SubdomainCallingFormat, so it could be incompatible if using different types likes OrdinaryCallingFormat .

for ex : boto-rsync -v -a 'xxxxxxxxxxx' -s 'yyyyyyyyyyyyyyyyy' --call-format boto.s3.connection.OrdinaryCallingFormat  -g 'public-read' /path/to/folder s3://mybucket/
