### PR TITLE
Fix bug preventing --delete from removing directories with subdirectories

### DIFF
--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -889,7 +889,7 @@ def main():
             
             # If specified, perform deletes
             if delete:
-                for root, dirs, files in os.walk(path):
+                for root, dirs, files in os.walk(path, topdown=False):
                     if no_recurse:
                         if root != path:
                             continue

--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/home/rob/.virtualenvs/erohisms/bin/python
 # Copyright (c) 2012 Seth Davis http://www.curiasolutions.com/
 # s3put is Copyright (c) 2006,2007,2008 Mitch Garnaat http://garnaat.org/
 #
@@ -21,11 +21,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-import sys, os, time, datetime, argparse, threading, signal
+import sys, os, re, time, datetime, argparse, threading, signal, hashlib
 from fnmatch import fnmatch
 import boto
 
-__version__ = '0.8.1'
+__version__ = '0.9.0'
 
 version= """
 %(prog)s v%(version)s
@@ -46,6 +46,20 @@ examples:
  or
     boto-rsync [OPTIONS] s3://bucketname/ s3://another_bucket/
 """
+
+_md5_cache = {}
+
+def md5(file_path):
+    if not _md5_cache.has_key(file_path):
+        with open(file_path, 'rb') as fh:
+            m = hashlib.md5()
+            while True:
+                data = fh.read(8192)
+                if not data:
+                    break
+                m.update(data)
+            _md5_cache[file_path] = u'"%s"' % m.hexdigest()
+    return _md5_cache[file_path]
 
 def usage(parser):
     """Prints the usage string and exits."""
@@ -457,7 +471,7 @@ def main():
                     if glob and not fnmatch(key.name.split('/')[-1], glob):
                         continue
                     
-                    keys[key.name] = key.size
+                    keys[key.name] = key.etag
             except Exception, e:
                 raise e
             finally:
@@ -503,7 +517,7 @@ def main():
                              key_name.endswith('_$folder$'):
                             if not quiet:
                                 sys.stdout.write(
-                                    'Skipping %s (size matches)\n' %
+                                    'Skipping %s (md5 matches)\n' %
                                     key_name.replace('_$folder$', '/')
                                     )
                             create_dirkey = False
@@ -541,7 +555,6 @@ def main():
                     fullpath = os.path.join(root, file)
                     key_name = cloud_path + get_key_name(fullpath, path)
                     file_size = os.path.getsize(fullpath)
-                    
                     if file_size == 0:
                         if ignore_empty:
                             if not quiet:
@@ -559,10 +572,10 @@ def main():
                                     fullpath[len(path):].lstrip(os.sep)
                                     )
                             continue
-                        elif keys[key_name] == file_size:
+                        elif keys[key_name] == md5(fullpath):
                             if not quiet:
                                 sys.stdout.write(
-                                    'Skipping %s (size matches)\n' %
+                                    'Skipping %s (md5 matches)\n' %
                                     fullpath[len(path):].lstrip(os.sep)
                                     )
                             continue
@@ -589,7 +602,7 @@ def main():
                                 policy=grant, reduced_redundancy=reduced,
                                 encrypt_key=encrypt
                                 )
-                        keys[key_name] = file_size
+                        keys[key_name] = md5(fullpath)
                         
                         # Clean stdout
                         sys.stdout.write('\n')
@@ -621,7 +634,7 @@ def main():
                         if key_name in keys:
                             del(keys[key_name])
                 
-                for key_name, key_size in keys.iteritems():
+                for key_name, key_md5 in keys.iteritems():
                     sys.stdout.write(
                         'deleting %s\n' %
                         key_name[len(cloud_path):].replace('_$folder$', '/')
@@ -663,16 +676,16 @@ def main():
                         else:
                             sys.stdout.write('Skipping %s (not overwriting)\n' %
                                              filename)
-                elif key.size == file_size:
+                elif key.etag == md5(fullpath):
                     copy_file = False
                     if not quiet:
                         if filename != key_name.split('/')[-1]:
                             sys.stdout.write(
-                                'Skipping %s -> %s (size matches)\n' %
+                                'Skipping %s -> %s (md5 matches)\n' %
                                 filename, key_name.split('/')[-1]
                                 )
                         else:
-                            sys.stdout.write('Skipping %s (size matches)\n' %
+                            sys.stdout.write('Skipping %s (md5 matches)\n' %
                                              filename)
             
             if copy_file:
@@ -766,17 +779,17 @@ def main():
                                 fullpath.split(os.sep)[-1]
                                 )
                     copy_file = False
-                elif key.size == os.path.getsize(fullpath):
+                elif key.etag == md5(fullpath):
                     if not quiet:
                         if rename:
                             sys.stdout.write(
-                                'Skipping %s -> %s (size matches)\n' %
+                                'Skipping %s -> %s (md5 matches)\n' %
                                 keypath.replace('/', os.sep),
                                 fullpath.split(os.sep)[-1]
                                 )
                         else:
                             sys.stdout.write(
-                                'Skipping %s (size matches)\n' %
+                                'Skipping %s (md5 matches)\n' %
                                 fullpath.split(os.sep)[-1]
                                 )
                     copy_file = False
@@ -856,12 +869,12 @@ def main():
                                 fullpath[len(os.path.join(path, '')):]
                                 )
                         continue
-                    elif key.size == os.path.getsize(fullpath) or \
+                    elif key.etag == md5(fullpath) or \
                          key.name.endswith('/') or \
                          key.name.endswith('_$folder$'):
                         if not quiet:
                             sys.stdout.write(
-                                'Skipping %s (size matches)\n' %
+                                'Skipping %s (md5 matches)\n' %
                                 fullpath[len(os.path.join(path, '')):]
                                 )
                         continue
@@ -976,16 +989,16 @@ def main():
                                 'Skipping %s (not overwriting)\n' % fullpath
                                 )
                     copy_file = False
-                elif key.size == dest_key.size:
+                elif key.etag == dest_key.etag:
                     if not quiet:
                         if rename:
                             sys.stdout.write(
-                                'Skipping %s -> %s (size matches)\n' %
+                                'Skipping %s -> %s (md5 matches)\n' %
                                 keypath.split('/')[-1], fullpath.split('/')[-1]
                                 )
                         else:
                             sys.stdout.write(
-                                'Skipping %s (size matches)\n' % fullpath
+                                'Skipping %s (md5 matches)\n' % fullpath
                                 )
                     copy_file = False
             
@@ -1084,10 +1097,10 @@ def main():
                                 fullpath.replace('_$folder$', '/')
                                 )
                         continue
-                    elif key.size == dest_key.size:
+                    elif key.etag == dest_key.etag:
                         if not quiet:
                             sys.stdout.write(
-                                'Skipping %s (size matches)\n' %
+                                'Skipping %s (md5 matches)\n' %
                                 fullpath.replace('_$folder$', '/')
                                 )
                         continue

--- a/bin/boto-rsync
+++ b/bin/boto-rsync
@@ -185,6 +185,15 @@ def signal_handler(signum, frame):
         sys.stdout.write('\n')
         sys.exit(0)
 
+def update_metadata(k, metadata, metadata_mappings, file):
+    if metadata_mappings:
+        for mapping in metadata_mappings:
+            if re.match(mapping[0], file):
+                k.update_metadata(mapping[1])
+                break
+    else:
+        k.update_metadata(metadata)
+
 def main():
     global speeds, ev
     
@@ -238,6 +247,10 @@ def main():
              'so that SOURCE and DESTINATION can be read properly. e.g. ' + \
              '%(prog)s -m "Content-Type: audio/mpeg" "Content-Disposition: ' + \
              'attachment" -- ./path/ s3://bucket/'
+        )
+    parser.add_argument(
+        '-f', '--metadata-file', metavar='METAFILE', dest='metadata_file',
+        help=''
         )
     parser.add_argument(
         '-r', '--reduced', action='store_true',
@@ -331,6 +344,9 @@ def main():
         metadata = args.metadata
         if not isinstance(metadata, dict):
             metadata = dict([meta.split(': ', 1) for meta in metadata])
+        metadata_mappings = args.metadata_file
+        if metadata_mappings:
+            metadata_mappings = __import__(metadata_mappings).metadata_mappings
         reduced = args.reduced
         encrypt = args.encrypt
         preserve = args.preserve
@@ -591,7 +607,7 @@ def main():
                         
                         # Send the file
                         k = b.new_key(key_name)
-                        k.update_metadata(metadata)
+                        update_metadata(k, metadata, metadata_mappings, file)
                         if cloud_service == 'gs':
                             k.set_contents_from_filename(
                                 fullpath, cb=cb, num_cb=num_cb, policy=grant
@@ -701,7 +717,7 @@ def main():
                     
                     # Send the file
                     k = b.new_key(key_name)
-                    k.update_metadata(metadata)
+                    update_metadata(k, metadata, metadata_mappings, file)
                     if cloud_service == 'gs':
                         k.set_contents_from_filename(
                             path, cb=cb, num_cb=num_cb, policy=grant


### PR DESCRIPTION
Adds the topdown=False argument to os.walk() to traverse directories marked for deletion bottom-up. Previously, given a directory "a" containing subdirectory "a/b", boto-rsync would attempt to delete "a" first, which would fail due to being non-empty.
